### PR TITLE
fix: resolve markdownv2 parsing issue and deep copy bug in plugin.SafeString()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,8 +143,15 @@ func (p *Plugin) Validate() error {
 // SafeString returns a string representation of the plugin configuration
 // with sensitive data masked
 func (p *Plugin) SafeString() string {
-	// Create a deep copy of the config to avoid modifying the original
-	configCopy := *p
+	// Create a deep copy using json marshal/unmarshal
+	var configCopy Plugin
+	data, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Sprintf("Error copying config: %v", err)
+	}
+	if err := json.Unmarshal(data, &configCopy); err != nil {
+		return fmt.Sprintf("Error copying config: %v", err)
+	}
 
 	// Mask Gotify client token
 	configCopy.Settings.GotifyServer.ClientToken = utils.MaskToken(configCopy.Settings.GotifyServer.ClientToken)

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -60,7 +60,7 @@ func (c *Client) Send(message api.Message, token, chatID string, formatOpts conf
 		Str("chat_id", chatID).
 		Msg("preparing to send message to Telegram")
 
-	formattedMessage, err := FormatMessage(message.Message, formatOpts)
+	formattedMessage, err := FormatMessage(message, formatOpts)
 	if err != nil {
 		c.errChan <- fmt.Errorf("failed to format message: %w", err)
 		return

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -60,7 +60,11 @@ func (c *Client) Send(message api.Message, token, chatID string, formatOpts conf
 		Str("chat_id", chatID).
 		Msg("preparing to send message to Telegram")
 
-	formattedMessage := formatMessageForTelegram(message, formatOpts, c.logger)
+	formattedMessage, err := FormatMessage(message.Message, formatOpts)
+	if err != nil {
+		c.errChan <- fmt.Errorf("failed to format message: %w", err)
+		return
+	}
 
 	payload := Payload{
 		ChatID:    chatID,
@@ -77,6 +81,7 @@ func (c *Client) Send(message api.Message, token, chatID string, formatOpts conf
 	endpoint := c.buildBotEndpoint(token)
 	c.logger.Debug().
 		Str("endpoint", strings.Replace(endpoint, token, "***", 1)).
+		Str("formattedMessage", formattedMessage).
 		Str("payload", string(body)).
 		Msg("sending request to Telegram API")
 

--- a/internal/telegram/format.go
+++ b/internal/telegram/format.go
@@ -3,200 +3,119 @@ package telegram
 import (
 	"fmt"
 	"regexp"
-	"sort"
+	"strconv"
 	"strings"
-	"time"
 
-	"github.com/0xPeterSatoshi/gotify-to-telegram/internal/api"
 	"github.com/0xPeterSatoshi/gotify-to-telegram/internal/config"
-	"github.com/rs/zerolog"
 )
 
-// Regular expression to find markdown links
-var linkRegex = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+// charactersToEscape contains all special characters that need to be escaped in regular text
+var charactersToEscape = []string{"_", "*", "[", "]", "(", ")", "~", "`", ">", "#", "+", "-", "=", "|", "{", "}", ".", "!"}
 
-// processMarkdownLinks processes markdown links in the given text
-func processMarkdownLinks(text string, logger *zerolog.Logger) string {
-	// If text doesn't contain valid links (i.e., both '[' and '](' must be present)
-	if !strings.Contains(text, "](") {
-		return escapeMarkdownV2(text)
-	}
+// urlRegex matches URLs in the text
+var urlRegex = regexp.MustCompile(`https?://[^\s]+`)
 
-	// Process all matches at once using regex
-	return linkRegex.ReplaceAllStringFunc(text, func(match string) string {
-		// Extract link text and URL using regex submatches
-		submatches := linkRegex.FindStringSubmatch(match)
-		if len(submatches) != 3 {
-			logger.Error().Msg("Invalid link format found")
-			return escapeMarkdownV2(match)
-		}
+// imageMarkdownRegex matches image markdown syntax
+var imageMarkdownRegex = regexp.MustCompile(`!\[([^\]]*)\]\(([^)]+)\)`)
 
-		linkText := submatches[1]
-		url := submatches[2]
+// inlineURLRegex matches inline URL markdown syntax
+var inlineURLRegex = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
 
-		// Escape the link text and URL separately
-		escapedLinkText := escapeMarkdownV2(linkText)
-		escapedURL := escapeURLForMarkdown(url)
-
-		// Return the properly formatted markdown link
-		return fmt.Sprintf("[%s](%s)", escapedLinkText, escapedURL)
-	})
-}
-
-// escapeURLForMarkdown escapes specific characters in URLs
-func escapeURLForMarkdown(url string) string {
-	var result strings.Builder
-	result.Grow(len(url) * 2) // Pre-allocate space for worst case
-
-	// Keep track of nested parentheses
-	parenDepth := 0
-
-	for _, char := range url {
-		switch char {
-		case '(':
-			parenDepth++
-			result.WriteString("\\(")
-		case ')':
-			parenDepth--
-			// Always escape a closing parenthesis
-			result.WriteString("\\)")
-		default:
-			result.WriteRune(char)
-		}
-	}
-
-	return result.String()
-}
-
-// escapeMarkdownV2 escapes specific characters in MarkdownV2
-func escapeMarkdownV2(s string) string {
-	// Characters that need escaping in MarkdownV2
-	specialChars := []string{
-		"_", "*", "[", "]", "(", ")", "~", "`", ">",
-		"#", "+", "-", "=", "|", "{", "}", ".", "!",
-	}
-
-	result := s
-	for _, char := range specialChars {
-		result = strings.ReplaceAll(result, char, "\\"+char)
-	}
-	return result
-}
-
-// convertImageMarkdownToURL converts image markdown to plain URLs
-func convertImageMarkdownToURL(message string, logger *zerolog.Logger) string {
-	imgRegex := regexp.MustCompile(`!\[\]\((.*?)\)`)
-	return imgRegex.ReplaceAllStringFunc(message, func(match string) string {
-		submatches := imgRegex.FindStringSubmatch(match)
-		if len(submatches) != 2 {
-			logger.Error().Msg("Invalid image markdown format")
-			return match
-		}
-		return submatches[1] // Return just the URL
-	})
-}
-
-// formatTitle formats the title for Telegram
-func formatTitle(msg api.Message) string {
-	return fmt.Sprintf("[%s] %s", msg.AppName, msg.Title)
-}
-
-// formatExtras handles the recursive formatting of nested maps
-func formatExtras(builder *strings.Builder, extras map[string]interface{}, prefix string, logger *zerolog.Logger) {
-	// Get keys and sort them
-	keys := make([]string, 0, len(extras))
-	for key := range extras {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		value := extras[key]
-		escapedKey := escapeMarkdownV2(key)
-
-		// Handle nested maps
-		if nestedMap, ok := value.(map[string]interface{}); ok {
-			builder.WriteString(fmt.Sprintf("\n%s• %s:", prefix, escapedKey))
-			formatExtras(builder, nestedMap, prefix+"  ", logger) // Increase indentation for nested items
+// escapeSpecialCharacters escapes all special characters in a text string
+func escapeSpecialCharacters(text string) string {
+	escaped := text
+	for _, char := range charactersToEscape {
+		// Don't escape backslashes that are part of \n
+		if strings.Contains(escaped, `\n`) {
+			parts := strings.Split(escaped, `\n`)
+			for i, part := range parts {
+				if char != `\` { // Don't escape backslashes
+					parts[i] = strings.ReplaceAll(part, char, `\`+char)
+				}
+			}
+			escaped = strings.Join(parts, `\n`)
 		} else {
-			// Format simple values
-			escapedValue := escapeMarkdownV2(fmt.Sprint(value))
-			builder.WriteString(fmt.Sprintf("\n%s• %s: `%s`", prefix, escapedKey, escapedValue))
+			escaped = strings.ReplaceAll(escaped, char, `\`+char)
 		}
 	}
+	return escaped
 }
 
-// formatMessageForTelegram formats the message for Telegram
-func formatMessageForTelegram(msg api.Message, formatOpts config.MessageFormatOptions, logger *zerolog.Logger) string {
-	var (
-		builder      strings.Builder
-		messageTitle string
-	)
-
-	// Title in bold
-	if msg.Title != "" {
-		if formatOpts.IncludeAppName {
-			messageTitle = formatTitle(msg)
-		} else {
-			messageTitle = msg.Title
-		}
-		builder.WriteString(fmt.Sprintf("*%s*\n\n", escapeMarkdownV2(messageTitle)))
-	}
-
-	// Process the message content
-	messageContent := msg.Message
-
-	// First convert any image markdown to plain URLs
-	if strings.Contains(messageContent, "![](") {
-		messageContent = convertImageMarkdownToURL(messageContent, logger)
-	}
-
-	// Then handle any regular markdown links
-	messageContent = processMarkdownLinks(messageContent, logger)
-
-	// Escape any remaining special characters in the message
-	// But avoid escaping the already processed links
-	parts := strings.Split(messageContent, "\n")
-	for i, part := range parts {
-		if !strings.Contains(part, "](") { // Only escape lines that don't contain links
-			parts[i] = escapeMarkdownV2(part)
-		}
-	}
-	messageContent = strings.Join(parts, "\n")
-
-	builder.WriteString(messageContent + "\n")
-
-	// Priority indicator using emojis
-	if int(msg.Priority) > formatOpts.PriorityThreshold && formatOpts.IncludePriority {
-		builder.WriteString("\n")
-		builder.WriteString(escapeMarkdownV2(getPriorityIndicator(int(msg.Priority))))
-	}
-
-	// Add any extras if present and not empty
-	if len(msg.Extras) > 0 && formatOpts.IncludeExtras {
-		builder.WriteString("\n*Additional Info:*")
-		formatExtras(&builder, msg.Extras, "", logger)
-	}
-
-	// Add timestamp
-	if formatOpts.IncludeTimestamp {
-		formattedTimestamp := time.Now().Format(time.RFC3339)
-		builder.WriteString(fmt.Sprintf("\n\ntimestamp: %s", escapeMarkdownV2(formattedTimestamp)))
-	}
-
-	return builder.String()
+// formatPlainURL escapes special characters in a URL
+func formatPlainURL(url string) string {
+	return escapeSpecialCharacters(url)
 }
 
-// getPriorityIndicator returns the emoji indicator for the priority
-func getPriorityIndicator(priority int) string {
-	switch {
-	case priority >= 8:
-		return "🔴 Critical Priority"
-	case priority >= 6:
-		return "🟠 High Priority"
-	case priority >= 4:
-		return "🟡 Medium Priority"
+// extractAndFormatImageURL extracts the URL from an image markdown and formats it
+func extractAndFormatImageURL(imageMarkdown string) string {
+	matches := imageMarkdownRegex.FindStringSubmatch(imageMarkdown)
+	if len(matches) < 3 {
+		return imageMarkdown
+	}
+	return matches[2]
+}
+
+// preserveInlineURL keeps the inline URL markdown format intact
+func preserveInlineURL(inlineURL string) string {
+	// Since the inline URL format is allowed, we return it as is
+	return inlineURL
+}
+
+func formatMessageAsMarkdownV2(input string) string {
+	// First, collect all inline URLs to preserve them
+	inlineURLs := make(map[string]string)
+	currentText := input
+
+	// Preserve inline URLs by replacing them with placeholders
+	currentText = inlineURLRegex.ReplaceAllStringFunc(currentText, func(match string) string {
+		placeholder := "INLINEURL" + strconv.Itoa(len(inlineURLs))
+		inlineURLs[placeholder] = match
+		return placeholder
+	})
+
+	// Handle image markdown by extracting and formatting URLs
+	currentText = imageMarkdownRegex.ReplaceAllStringFunc(currentText, func(match string) string {
+		return extractAndFormatImageURL(match)
+	})
+
+	// Format plain URLs
+	currentText = urlRegex.ReplaceAllStringFunc(currentText, func(match string) string {
+		// Skip if this URL is part of our preserved inline URLs
+		for _, preserved := range inlineURLs {
+			if strings.Contains(preserved, match) {
+				return match
+			}
+		}
+		return formatPlainURL(match)
+	})
+
+	// Escape special characters in the remaining text
+	words := strings.Split(currentText, " ")
+	for i, word := range words {
+		// Skip if this is one of our placeholders
+		if _, isPreserved := inlineURLs[word]; !isPreserved {
+			// Skip if this word is already a formatted URL
+			if !urlRegex.MatchString(word) {
+				words[i] = escapeSpecialCharacters(word)
+			}
+		}
+	}
+	currentText = strings.Join(words, " ")
+
+	// Restore preserved inline URLs
+	for placeholder, original := range inlineURLs {
+		currentText = strings.ReplaceAll(currentText, placeholder, original)
+	}
+
+	return currentText
+}
+
+// FormatMessage formats the input text according to Telegram MarkdownV2 rules
+func FormatMessage(input string, formatOpts config.MessageFormatOptions) (string, error) {
+	switch formatOpts.ParseMode {
+	case "MarkdownV2":
+		return formatMessageAsMarkdownV2(input), nil
 	default:
-		return "🟢 Low Priority"
+		return "", fmt.Errorf("parse mode %s is not supported", formatOpts.ParseMode)
 	}
 }

--- a/internal/telegram/format.go
+++ b/internal/telegram/format.go
@@ -3,9 +3,12 @@ package telegram
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/0xPeterSatoshi/gotify-to-telegram/internal/api"
 	"github.com/0xPeterSatoshi/gotify-to-telegram/internal/config"
 )
 
@@ -21,8 +24,8 @@ var imageMarkdownRegex = regexp.MustCompile(`!\[([^\]]*)\]\(([^)]+)\)`)
 // inlineURLRegex matches inline URL markdown syntax
 var inlineURLRegex = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
 
-// escapeSpecialCharacters escapes all special characters in a text string
-func escapeSpecialCharacters(text string) string {
+// escapeMarkdownV2 escapes all special characters in a text string
+func escapeMarkdownV2(text string) string {
 	escaped := text
 	for _, char := range charactersToEscape {
 		// Don't escape backslashes that are part of \n
@@ -43,7 +46,7 @@ func escapeSpecialCharacters(text string) string {
 
 // formatPlainURL escapes special characters in a URL
 func formatPlainURL(url string) string {
-	return escapeSpecialCharacters(url)
+	return escapeMarkdownV2(url)
 }
 
 // extractAndFormatImageURL extracts the URL from an image markdown and formats it
@@ -96,7 +99,7 @@ func formatMessageAsMarkdownV2(input string) string {
 		if _, isPreserved := inlineURLs[word]; !isPreserved {
 			// Skip if this word is already a formatted URL
 			if !urlRegex.MatchString(word) {
-				words[i] = escapeSpecialCharacters(word)
+				words[i] = escapeMarkdownV2(word)
 			}
 		}
 	}
@@ -110,12 +113,93 @@ func formatMessageAsMarkdownV2(input string) string {
 	return currentText
 }
 
+// formatTitle formats the title for Telegram
+func formatTitle(msg api.Message) string {
+	return fmt.Sprintf("[%s] %s", msg.AppName, msg.Title)
+}
+
+// formatExtras handles the recursive formatting of nested maps
+func formatExtras(builder *strings.Builder, extras map[string]interface{}, prefix string) {
+	// Get keys and sort them
+	keys := make([]string, 0, len(extras))
+	for key := range extras {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := extras[key]
+		escapedKey := escapeMarkdownV2(key)
+
+		// Handle nested maps
+		if nestedMap, ok := value.(map[string]interface{}); ok {
+			builder.WriteString(fmt.Sprintf("\n%s• %s:", prefix, escapedKey))
+			formatExtras(builder, nestedMap, prefix+"  ") // Increase indentation for nested items
+		} else {
+			// Format simple values
+			escapedValue := escapeMarkdownV2(fmt.Sprint(value))
+			builder.WriteString(fmt.Sprintf("\n%s• %s: `%s`", prefix, escapedKey, escapedValue))
+		}
+	}
+
+	builder.WriteString("\n\n")
+}
+
+// getPriorityIndicator returns the emoji indicator for the priority
+func getPriorityIndicator(priority int) string {
+	switch {
+	case priority >= 8:
+		return "🔴 Critical Priority"
+	case priority >= 6:
+		return "🟠 High Priority"
+	case priority >= 4:
+		return "🟡 Medium Priority"
+	default:
+		return "🟢 Low Priority"
+	}
+}
+
 // FormatMessage formats the input text according to Telegram MarkdownV2 rules
-func FormatMessage(input string, formatOpts config.MessageFormatOptions) (string, error) {
+func FormatMessage(msg api.Message, formatOpts config.MessageFormatOptions) (string, error) {
+	var (
+		builder      strings.Builder
+		messageTitle string
+	)
+
+	// Title in bold
+	if msg.Title != "" {
+		if formatOpts.IncludeAppName {
+			messageTitle = formatTitle(msg)
+		} else {
+			messageTitle = msg.Title
+		}
+		builder.WriteString(fmt.Sprintf("*%s*\n\n", escapeMarkdownV2(messageTitle)))
+	}
+
 	switch formatOpts.ParseMode {
 	case "MarkdownV2":
-		return formatMessageAsMarkdownV2(input), nil
+		message := formatMessageAsMarkdownV2(msg.Message)
+		builder.WriteString(message + "\n\n")
 	default:
 		return "", fmt.Errorf("parse mode %s is not supported", formatOpts.ParseMode)
 	}
+
+	// Priority indicator using emojis
+	if int(msg.Priority) > formatOpts.PriorityThreshold && formatOpts.IncludePriority {
+		builder.WriteString(escapeMarkdownV2(getPriorityIndicator(int(msg.Priority))) + "\n\n")
+	}
+
+	// Add any extras if present and not empty
+	if len(msg.Extras) > 0 && formatOpts.IncludeExtras {
+		builder.WriteString("*Additional Info:*")
+		formatExtras(&builder, msg.Extras, "")
+	}
+
+	// Add timestamp
+	if formatOpts.IncludeTimestamp {
+		formattedTimestamp := time.Now().Format(time.RFC3339)
+		builder.WriteString(fmt.Sprintf("timestamp: %s", escapeMarkdownV2(formattedTimestamp)) + "\n")
+	}
+
+	return builder.String(), nil
 }

--- a/internal/telegram/format_test.go
+++ b/internal/telegram/format_test.go
@@ -1,348 +1,141 @@
 package telegram
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/0xPeterSatoshi/gotify-to-telegram/internal/api"
 	"github.com/0xPeterSatoshi/gotify-to-telegram/internal/config"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestProcessMarkdownLinks(t *testing.T) {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
-
+func TestEscapeSpecialCharacters(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
 		expected string
 	}{
 		{
-			name:     "simple link",
-			input:    "[text](https://example.com)",
-			expected: "[text](https://example.com)",
+			name:     "basic special characters",
+			input:    "Hello! This is a (test) with [brackets]",
+			expected: "Hello\\! This is a \\(test\\) with \\[brackets\\]",
 		},
 		{
-			name:     "link with special characters",
-			input:    "[test!](https://example.com/test!)",
-			expected: "[test\\!](https://example.com/test!)",
-		},
-		{
-			name:     "multiple links",
-			input:    "[link1](url1) and [link2](url2)",
-			expected: "[link1](url1) and [link2](url2)",
-		},
-		{
-			name:     "invalid link format",
-			input:    "[broken link(http://example.com)",
-			expected: "\\[broken link\\(http://example\\.com\\)",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := processMarkdownLinks(tt.input, &logger)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestEscapeURLForMarkdown(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "url with parentheses",
-			input:    "http://example.com/path(1)",
-			expected: "http://example.com/path\\(1\\)",
-		},
-		{
-			name:     "simple url",
-			input:    "http://example.com",
-			expected: "http://example.com",
-		},
-		{
-			name:     "url with nested parentheses",
-			input:    "http://example.com/(test(1))",
-			expected: "http://example.com/\\(test\\(1\\)\\)",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := escapeURLForMarkdown(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestEscapeMarkdownV2(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "special characters",
-			input:    "Hello *world* with _emphasis_!",
-			expected: "Hello \\*world\\* with \\_emphasis\\_\\!",
-		},
-		{
-			name:     "code and links",
-			input:    "Check `this` and [that]",
-			expected: "Check \\`this\\` and \\[that\\]",
-		},
-		{
-			name:     "dots and dashes",
-			input:    "Example.com - test",
-			expected: "Example\\.com \\- test",
+			name:     "multiple special characters",
+			input:    "test.test-test_test",
+			expected: "test\\.test\\-test\\_test",
 		},
 		{
 			name:     "no special characters",
-			input:    "Hello world",
-			expected: "Hello world",
+			input:    "Hello World",
+			expected: "Hello World",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := escapeMarkdownV2(tt.input)
-			assert.Equal(t, tt.expected, result)
+			result := escapeSpecialCharacters(tt.input)
+			if result != tt.expected {
+				t.Errorf("escapeSpecialCharacters(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
 		})
 	}
 }
 
-func TestConvertImageMarkdownToURL(t *testing.T) {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
-
+func TestFormatPlainURL(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
 		expected string
 	}{
 		{
-			name:     "single image",
-			input:    "![](https://example.com/image.jpg)",
-			expected: "https://example.com/image.jpg",
+			name:     "simple URL",
+			input:    "https://example.com",
+			expected: "https://example\\.com",
 		},
 		{
-			name:     "multiple images",
-			input:    "![](image1.jpg)\n![](image2.jpg)",
-			expected: "image1.jpg\nimage2.jpg",
+			name:     "complex URL",
+			input:    "https://example.com/path-to/something.html",
+			expected: "https://example\\.com/path\\-to/something\\.html",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatPlainURL(tt.input)
+			if result != tt.expected {
+				t.Errorf("formatPlainURL(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractAndFormatImageURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic image markdown",
+			input:    "![](https://example.com/image.jpg)",
+			expected: "https://example\\.com/image\\.jpg",
+		},
+		{
+			name:     "image markdown with alt text",
+			input:    "![alt text](https://example.com/image.jpg)",
+			expected: "https://example\\.com/image\\.jpg",
 		},
 		{
 			name:     "invalid image markdown",
-			input:    "![broken(image.jpg)",
-			expected: "![broken(image.jpg)",
-		},
-		{
-			name:     "mixed content",
-			input:    "Text ![](image.jpg) more text",
-			expected: "Text image.jpg more text",
+			input:    "![invalid markdown",
+			expected: "![invalid markdown",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertImageMarkdownToURL(tt.input, &logger)
-			assert.Equal(t, tt.expected, result)
+			result := extractAndFormatImageURL(tt.input)
+			if result != tt.expected {
+				t.Errorf("extractAndFormatImageURL(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
 		})
 	}
 }
 
-func TestFormatExtras(t *testing.T) {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
-	var builder strings.Builder
-
-	tests := []struct {
-		name     string
-		extras   map[string]interface{}
-		prefix   string
-		expected string
-	}{
-		{
-			name: "simple extras",
-			extras: map[string]interface{}{
-				"key1": "value1",
-				"key2": 123,
-			},
-			prefix:   "",
-			expected: "\n• key1: `value1`\n• key2: `123`",
-		},
-		{
-			name: "nested extras",
-			extras: map[string]interface{}{
-				"outer": map[string]interface{}{
-					"inner": "value",
-				},
-			},
-			prefix:   "",
-			expected: "\n• outer:\n  • inner: `value`",
-		},
-		{
-			name: "mixed types",
-			extras: map[string]interface{}{
-				"string": "text",
-				"number": 42,
-				"bool":   true,
-			},
-			prefix:   "",
-			expected: "\n• bool: `true`\n• number: `42`\n• string: `text`",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			builder.Reset()
-			formatExtras(&builder, tt.extras, tt.prefix, &logger)
-			assert.Equal(t, tt.expected, builder.String())
-		})
-	}
-}
-
-func TestFormatMessageForTelegram(t *testing.T) {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
-
+func TestFormatText(t *testing.T) {
 	tests := []struct {
 		name       string
-		message    api.Message
-		formatOpts config.MessageFormatOptions
+		input      string
 		expected   string
+		formatOpts config.MessageFormatOptions
 	}{
 		{
-			name: "basic message",
-			message: api.Message{
-				Title:   "Test Title",
-				Message: "Test Message",
-				AppName: "TestApp",
-			},
-			formatOpts: config.MessageFormatOptions{
-				IncludeAppName:   true,
-				IncludeTimestamp: false,
-			},
-			expected: "*\\[TestApp\\] Test Title*\n\nTest Message\n",
+			name: "complex text with multiple elements",
+			input: `Terminator Salvation (2009) [Remux-1080p] https://www.imdb.com/title/tt0438488/
+![](https://image.tmdb.org/t/p/original/gw6JhlekZgtKUFlDTezq3j5JEPK.jpg)
+[some url here](https://imdb.com)`,
+			expected: `Terminator Salvation \\(2009\\) \\[Remux\\-1080p\\] https://www\\.imdb\\.com/title/tt0438488/
+https://image\\.tmdb\\.org/t/p/original/gw6JhlekZgtKUFlDTezq3j5JEPK\\.jpg
+[some url here](https://imdb.com)`,
 		},
 		{
-			name: "message with priority",
-			message: api.Message{
-				Title:    "Priority Test",
-				Message:  "Important Message",
-				Priority: 8,
-			},
-			formatOpts: config.MessageFormatOptions{
-				IncludeAppName:    false,
-				IncludePriority:   true,
-				PriorityThreshold: 5,
-			},
-			expected: "*Priority Test*\n\nImportant Message\n\n🔴 Critical Priority",
+			name:     "text with inline URL",
+			input:    "Check out this [link](https://example.com/test.html) and this text.",
+			expected: "Check out this [link](https://example.com/test.html) and this text\\.",
 		},
 		{
-			name: "message with extras",
-			message: api.Message{
-				Title:   "Extras Test",
-				Message: "Test with extras",
-				Extras: map[string]interface{}{
-					"key": "value",
-				},
-			},
-			formatOpts: config.MessageFormatOptions{
-				IncludeExtras: true,
-			},
-			expected: "*Extras Test*\n\nTest with extras\n\n*Additional Info:*\n• key: `value`",
-		},
-		{
-			name: "message with markdown",
-			message: api.Message{
-				Title:   "Markdown Test",
-				Message: "[link](https://example.com) and ![](image.jpg)",
-			},
-			formatOpts: config.MessageFormatOptions{},
-			expected:   "*Markdown Test*\n\n[link](https://example.com) and image.jpg\n",
+			name:     "text with plain URL",
+			input:    "Visit https://example.com/test.html for more info!",
+			expected: "Visit https://example\\.com/test\\.html for more info\\!",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatMessageForTelegram(tt.message, tt.formatOpts, &logger)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestGetPriorityIndicator(t *testing.T) {
-	tests := []struct {
-		name     string
-		priority int
-		expected string
-	}{
-		{
-			name:     "critical priority",
-			priority: 8,
-			expected: "🔴 Critical Priority",
-		},
-		{
-			name:     "high priority",
-			priority: 6,
-			expected: "🟠 High Priority",
-		},
-		{
-			name:     "medium priority",
-			priority: 4,
-			expected: "🟡 Medium Priority",
-		},
-		{
-			name:     "low priority",
-			priority: 2,
-			expected: "🟢 Low Priority",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getPriorityIndicator(tt.priority)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestFormatTitle(t *testing.T) {
-	tests := []struct {
-		name     string
-		message  api.Message
-		expected string
-	}{
-		{
-			name: "basic title",
-			message: api.Message{
-				AppName: "TestApp",
-				Title:   "Test Title",
-			},
-			expected: "[TestApp] Test Title",
-		},
-		{
-			name: "empty app name",
-			message: api.Message{
-				AppName: "",
-				Title:   "Test Title",
-			},
-			expected: "[] Test Title",
-		},
-		{
-			name: "empty title",
-			message: api.Message{
-				AppName: "TestApp",
-				Title:   "",
-			},
-			expected: "[TestApp] ",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := formatTitle(tt.message)
-			assert.Equal(t, tt.expected, result)
+			result, err := FormatMessage(tt.input, tt.formatOpts)
+			require.NoError(t, err)
+			if result != tt.expected {
+				t.Errorf("FormatText(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes formatting errors that were leading to incorrect MarkdownV2 text leading to bad request errors from the telegram API. Additionally fixes a deep copy bug in the `plugin.SafeString()` that was leading to 404 errors in the API due to `SafeString()` modifying the bot token.